### PR TITLE
Make deep path depth configurable

### DIFF
--- a/httpstaticserver.go
+++ b/httpstaticserver.go
@@ -48,15 +48,16 @@ type Directory struct {
 }
 
 type HTTPStaticServer struct {
-	Root            string
-	Prefix          string
-	Upload          bool
-	Delete          bool
-	Title           string
-	Theme           string
-	PlistProxy      string
-	GoogleTrackerID string
-	AuthType        string
+	Root             string
+	Prefix           string
+	Upload           bool
+	Delete           bool
+	Title            string
+	Theme            string
+	PlistProxy       string
+	GoogleTrackerID  string
+	AuthType         string
+	DeepPathMaxDepth int
 
 	indexes []IndexFileItem
 	m       *mux.Router
@@ -571,6 +572,7 @@ func (s *HTTPStaticServer) hJSONList(w http.ResponseWriter, r *http.Request) {
 	auth := s.readAccessConf(realPath)
 	auth.Upload = auth.canUpload(r)
 	auth.Delete = auth.canDelete(r)
+	maxDepth := s.DeepPathMaxDepth
 
 	// path string -> info os.FileInfo
 	fileInfoMap := make(map[string]os.FileInfo, 0)
@@ -615,7 +617,7 @@ func (s *HTTPStaticServer) hJSONList(w http.ResponseWriter, r *http.Request) {
 			lr.Name = filepath.ToSlash(name) // fix for windows
 		}
 		if info.IsDir() {
-			name := deepPath(realPath, info.Name())
+			name := deepPath(realPath, info.Name(), maxDepth)
 			lr.Name = name
 			lr.Path = filepath.Join(filepath.Dir(path), name)
 			lr.Type = "dir"
@@ -740,9 +742,8 @@ func (s *HTTPStaticServer) readAccessConf(realPath string) (ac AccessConf) {
 	return
 }
 
-func deepPath(basedir, name string) string {
+func deepPath(basedir, name string, maxDepth int) string {
 	// loop max 5, incase of for loop not finished
-	maxDepth := 5
 	for depth := 0; depth <= maxDepth; depth += 1 {
 		finfos, err := ioutil.ReadDir(filepath.Join(basedir, name))
 		if err != nil || len(finfos) != 1 {

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ type Configure struct {
 		ID     string `yaml:"id"`     // for oauth2
 		Secret string `yaml:"secret"` // for oauth2
 	} `yaml:"auth"`
+	DeepPathMaxDepth int `yaml:"deep-path-max-depth"`
 }
 
 type httpLogger struct{}
@@ -99,6 +100,7 @@ func parseFlags() error {
 	gcfg.Auth.OpenID = defaultOpenID
 	gcfg.GoogleTrackerID = "UA-81205425-2"
 	gcfg.Title = "Go HTTP File Server"
+	gcfg.DeepPathMaxDepth = 5
 
 	kingpin.HelpFlag.Short('h')
 	kingpin.Version(versionMessage())
@@ -121,6 +123,7 @@ func parseFlags() error {
 	kingpin.Flag("plistproxy", "plist proxy when server is not https").Short('p').StringVar(&gcfg.PlistProxy)
 	kingpin.Flag("title", "server title").StringVar(&gcfg.Title)
 	kingpin.Flag("google-tracker-id", "set to empty to disable it").StringVar(&gcfg.GoogleTrackerID)
+	kingpin.Flag("deep-path-max-depth", "set to -1 to not combine dirs").IntVar(&gcfg.DeepPathMaxDepth)
 
 	kingpin.Parse() // first parse conf
 
@@ -172,6 +175,7 @@ func main() {
 	ss.Upload = gcfg.Upload
 	ss.Delete = gcfg.Delete
 	ss.AuthType = gcfg.Auth.Type
+	ss.DeepPathMaxDepth = gcfg.DeepPathMaxDepth
 
 	if gcfg.PlistProxy != "" {
 		u, err := url.Parse(gcfg.PlistProxy)


### PR DESCRIPTION
*Problem*

When browsing network paths (e.g. CIFS/SAMBA or s3fs) listing the folders in a combined way can be super slow because 
it needs to list the dirs within the dirs within the dirs... 

I am referring to this feature in the README.md

>When only one dir under dir, path will combine two together

*Proposition*

In this PR, I added a setting that sets the maximum depth to walk into, that defaults to 5 (the current value). Now I can set this setting to -1 which disable the feature and only list one folder at the time. This leads to a faster browsing experience.


Thanks a lot for this project and please tell if how I can improve this if needed. That's my first Golang PR.