### PR TITLE
Add no-index option to disable indexing and search

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -64,6 +64,8 @@
             </template>
             [[end]]
           </ul>
+
+          [[if not .NoIndex ]]
           <form class="navbar-form navbar-right">
             <div class="input-group">
               <input type="text" name="search" class="form-control" placeholder="Search text" v-bind:value="search"
@@ -75,6 +77,7 @@
               </span>
             </div>
           </form>
+          [[end]]
           <ul id="nav-right-bar" class="nav navbar-nav navbar-right">
           </ul>
         </div>

--- a/httpstaticserver.go
+++ b/httpstaticserver.go
@@ -57,13 +57,14 @@ type HTTPStaticServer struct {
 	PlistProxy      string
 	GoogleTrackerID string
 	AuthType        string
+	NoIndex         bool
 
 	indexes []IndexFileItem
 	m       *mux.Router
 	bufPool sync.Pool // use sync.Pool caching buf to reduce gc ratio
 }
 
-func NewHTTPStaticServer(root string) *HTTPStaticServer {
+func NewHTTPStaticServer(root string, noIndex bool) *HTTPStaticServer {
 	// if root == "" {
 	// 	root = "./"
 	// }
@@ -81,19 +82,22 @@ func NewHTTPStaticServer(root string) *HTTPStaticServer {
 		bufPool: sync.Pool{
 			New: func() interface{} { return make([]byte, 32*1024) },
 		},
+		NoIndex: noIndex,
 	}
 
-	go func() {
-		time.Sleep(1 * time.Second)
-		for {
-			startTime := time.Now()
-			log.Println("Started making search index")
-			s.makeIndex()
-			log.Printf("Completed search index in %v", time.Since(startTime))
-			//time.Sleep(time.Second * 1)
-			time.Sleep(time.Minute * 10)
-		}
-	}()
+	if !noIndex {
+		go func() {
+			time.Sleep(1 * time.Second)
+			for {
+				startTime := time.Now()
+				log.Println("Started making search index")
+				s.makeIndex()
+				log.Printf("Completed search index in %v", time.Since(startTime))
+				//time.Sleep(time.Second * 1)
+				time.Sleep(time.Minute * 10)
+			}
+		}()
+	}
 
 	// routers for Apple *.ipa
 	m.HandleFunc("/-/ipa/plist/{path:.*}", s.hPlist)

--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ type Configure struct {
 		ID     string `yaml:"id"`     // for oauth2
 		Secret string `yaml:"secret"` // for oauth2
 	} `yaml:"auth"`
+	NoIndex bool `yaml:"no-index"`
 }
 
 type httpLogger struct{}
@@ -99,6 +100,7 @@ func parseFlags() error {
 	gcfg.Auth.OpenID = defaultOpenID
 	gcfg.GoogleTrackerID = "UA-81205425-2"
 	gcfg.Title = "Go HTTP File Server"
+	gcfg.NoIndex = false
 
 	kingpin.HelpFlag.Short('h')
 	kingpin.Version(versionMessage())
@@ -121,6 +123,7 @@ func parseFlags() error {
 	kingpin.Flag("plistproxy", "plist proxy when server is not https").Short('p').StringVar(&gcfg.PlistProxy)
 	kingpin.Flag("title", "server title").StringVar(&gcfg.Title)
 	kingpin.Flag("google-tracker-id", "set to empty to disable it").StringVar(&gcfg.GoogleTrackerID)
+	kingpin.Flag("no-index", "disable indexing").BoolVar(&gcfg.NoIndex)
 
 	kingpin.Parse() // first parse conf
 
@@ -164,7 +167,7 @@ func main() {
 		log.Printf("url prefix: %s", gcfg.Prefix)
 	}
 
-	ss := NewHTTPStaticServer(gcfg.Root)
+	ss := NewHTTPStaticServer(gcfg.Root, gcfg.NoIndex)
 	ss.Prefix = gcfg.Prefix
 	ss.Theme = gcfg.Theme
 	ss.Title = gcfg.Title


### PR DESCRIPTION
This PR adds an option --no-index that disable the indexing and search. It can be useful if indexing is slow (e.g. on network-attached folders) or simply because one does not need the search feature.

It apparently could also solve #128

Feel free to tell me how I can improve this PR if needed.

Have a nice day.