### PR TITLE
fix docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app/gohttpserver
 ADD . /app/gohttpserver
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags '-X main.VERSION=docker' -o gohttpserver
 
-FROM debian:stretch
+FROM debian:stable
 WORKDIR /app
 RUN mkdir -p /app/public
 RUN apt-get update && apt-get install -y ca-certificates


### PR DESCRIPTION
stretch not maintained
```
3.612 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found [IP: 151.101.202.132 80] 3.612 E: Some index files failed to download. They have been ignored, or old ones used instead. ------
Dockerfile:10
--------------------
   8 |     WORKDIR /app
   9 |     RUN mkdir -p /app/public
  10 | >>> RUN apt-get update && apt-get install -y ca-certificates
```