### PR TITLE
fix: prevent stored XSS in README preview (fixes #237)

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -192,7 +192,8 @@
           </h3>
         </div>
         <div class="panel-body">
-          <article class="markdown-body">{{{preview.contentHTML }}}
+          <!-- Escape README preview content to prevent stored XSS from uploaded markdown. -->
+          <article class="markdown-body">{{ preview.contentHTML }}
           </article>
         </div>
       </div>

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -88,6 +88,8 @@ var vm = new Vue({
           method: 'GET',
           success: function (res) {
             var converter = new showdown.Converter({
+              // Disable raw HTML passthrough so uploaded README.md cannot inject scripts.
+              noHTML: true,
               tables: true,
               omitExtraWLInCodeBlocks: true,
               parseImgDimensions: true,

--- a/httpstaticserver.go
+++ b/httpstaticserver.go
@@ -28,6 +28,8 @@ import (
 
 const YAMLCONF = ".ghs.yml"
 
+const contentSecurityPolicy = "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; media-src 'self'; connect-src 'self'; form-action 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'"
+
 type ApkInfo struct {
 	PackageName  string `json:"packageName"`
 	MainActivity string `json:"mainActivity"`
@@ -112,6 +114,8 @@ func NewHTTPStaticServer(root string, noIndex bool) *HTTPStaticServer {
 }
 
 func (s *HTTPStaticServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Defense-in-depth for uploaded content and README previews.
+	w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
 	s.m.ServeHTTP(w, r)
 }
 

--- a/httpstaticserver_test.go
+++ b/httpstaticserver_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHTTPStaticServerSetsContentSecurityPolicy(t *testing.T) {
+	root, err := os.MkdirTemp("", "gohttpserver-csp-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(root)
+
+	server := NewHTTPStaticServer(root, true)
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	server.ServeHTTP(recorder, request)
+
+	if got := recorder.Header().Get("Content-Security-Policy"); got != contentSecurityPolicy {
+		t.Fatalf("Content-Security-Policy header = %q, want %q", got, contentSecurityPolicy)
+	}
+}
+
+func TestReadmePreviewShowdownDisablesHTML(t *testing.T) {
+	data, err := os.ReadFile("assets/js/index.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(data), "noHTML: true") {
+		t.Fatal("showdown converter must disable raw HTML passthrough with noHTML: true")
+	}
+}
+
+func TestReadmePreviewTemplateEscapesContent(t *testing.T) {
+	data, err := os.ReadFile("assets/index.html")
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := string(data)
+
+	if strings.Contains(template, "{{{preview.contentHTML") || strings.Contains(template, "{{{ preview.contentHTML") {
+		t.Fatal("README preview must not use Vue raw-HTML triple curly interpolation")
+	}
+	if !strings.Contains(template, "{{ preview.contentHTML }}") {
+		t.Fatal("README preview must use escaped Vue double curly interpolation")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a stored cross-site scripting (XSS) vulnerability in the directory-listing UI where uploaded README.md files could execute arbitrary JavaScript in the gohttpserver origin.

## Vulnerability

The directory-listing UI auto-fetches README.md, converts markdown to HTML via Showdown **without disabling HTML pass-through**, and injects the result into Vue 1.x's raw-HTML interpolation directive (`{{{ ... }}}`). An attacker with upload rights can plant event-handler attributes (`onerror`, `onload`, etc.) that fire for every viewer of the directory.

## Changes

| File | Fix |
|------|-----|
| `assets/js/index.js` | Added `noHTML: true` to Showdown converter — strips raw HTML from markdown input |
| `assets/index.html` | Changed `{{{preview.contentHTML}}}` (raw HTML) to `{{ preview.contentHTML }}` (escaped) |
| `httpstaticserver.go` | Added `Content-Security-Policy` header as defense-in-depth |
| `httpstaticserver_test.go` | 3 new tests verifying CSP header, Showdown config, and template escaping |

## Verification

All tests pass:

```
=== RUN   TestHTTPStaticServerSetsContentSecurityPolicy   --- PASS
=== RUN   TestReadmePreviewShowdownDisablesHTML            --- PASS
=== RUN   TestReadmePreviewTemplateEscapesContent          --- PASS
=== RUN   TestSublimeContains                              --- PASS
=== RUN   TestCleanPath                                    --- PASS
=== RUN   TestExtractFromZip                               --- PASS
PASS
```

## References

- CWE-79: Improper Neutralization of Input During Web Page Generation
- Issue #237